### PR TITLE
22 for parents page navigates to homepage

### DIFF
--- a/LVDivWebsite/Components/NavLink-LVD.razor
+++ b/LVDivWebsite/Components/NavLink-LVD.razor
@@ -1,8 +1,6 @@
-﻿<li class="nav-item sc-navitem">
-    <a class="nav-link sc-navlink" href="@Url">
+﻿<NavLink class="nav-link sc-navitem" href="@Url">
         @Caption
-    </a>
-</li>
+</NavLink>
 
 @code {
 

--- a/LVDivWebsite/Shared/MainLayout.razor
+++ b/LVDivWebsite/Shared/MainLayout.razor
@@ -22,7 +22,6 @@
             id="main-nav">
                 <ul class="navbar-nav">
                     <NavLink_LVD Caption="Join" Url="/join"/>
-                    <NavLink_LVD Caption="For Parents" />
                     <NavLink_LVD Caption="Resources" Url="/resources"/>
                     <NavLink_LVD Caption="Contact" Url="/contact" />
                     <DonateButton/>

--- a/LVDivWebsite/wwwroot/styles/site.scss
+++ b/LVDivWebsite/wwwroot/styles/site.scss
@@ -10,6 +10,15 @@ body, input, textarea, select {
 h1 {
     color: #003662;
 }
+
+.nav-link:hover {
+    color: #F7941E !important;
+}
+
+.nav-link.active {
+    color: #808285 !important;
+}
+
 .sc-card-title {
     text-transform: uppercase;
     color: #ff9e0d;
@@ -17,6 +26,10 @@ h1 {
 
 .sc-footer {
     background-color: #003662;
+}
+
+.sc-navlink {
+    color: #ff9e0d;
 }
 
 .carousel-item img {

--- a/LVDivWebsite/wwwroot/styles/site.scss
+++ b/LVDivWebsite/wwwroot/styles/site.scss
@@ -16,7 +16,7 @@ h1 {
 }
 
 .nav-link.active {
-    color: #808285 !important;
+    color: #F7941E !important;
 }
 
 .sc-card-title {


### PR DESCRIPTION
This pull request includes several updates to the navigation components and styles in the `LVDivWebsite` project. The most important changes involve refactoring the `NavLink-LVD` component and updating the styles for navigation links.

### Navigation Component Refactoring:
* [`LVDivWebsite/Components/NavLink-LVD.razor`](diffhunk://#diff-655f35c9b69c0c3b53fd62925cc3120eb85ae90e85c72b17c715ae3746b03197L1-R3): Refactored the `NavLink-LVD` component to use the `NavLink` tag instead of an `li` and `a` combination for better integration with Blazor's navigation system.

### Updates to Navigation Links:
* [`LVDivWebsite/Shared/MainLayout.razor`](diffhunk://#diff-4d5e913126edf3402501c7e3a6f19b02891e701174b257972eca0e7e89bfa6c0L25): Removed the "For Parents" navigation link as it lacked a URL, ensuring all navigation links have a defined destination.

### Style Enhancements:
* [`LVDivWebsite/wwwroot/styles/site.scss`](diffhunk://#diff-1f231bfd732b790552da16e4f6568c672ffd1e4755defec60369d4d86deff176R13-R21): Added hover and active styles for `.nav-link` to change the color to `#F7941E` for better visual feedback.
* [`LVDivWebsite/wwwroot/styles/site.scss`](diffhunk://#diff-1f231bfd732b790552da16e4f6568c672ffd1e4755defec60369d4d86deff176R31-R34): Added a new style for `.sc-navlink` to set the color to `#ff9e0d` for consistency with the site's color scheme.